### PR TITLE
Update compare-envs.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ Thumbs.db
 
 *.env*
 
+*.json
+foobar
+foobar2
+SSM examples.txt

--- a/src/compare-envs.js
+++ b/src/compare-envs.js
@@ -32,7 +32,7 @@ var options = yargs
     .option('t', {
         alias: 'to',
         demandOption: true,
-        describe: 'The prefix for the source SSM values.',
+        describe: 'The prefix for the destination SSM values.',
         type: 'string'
     })
     .option('d', {
@@ -46,7 +46,7 @@ var options = yargs
         alias: 'destinationRegion',
         demandOption: false,
         default: 'us-east-1',
-        describe: 'The source AWS region.',
+        describe: 'The destination AWS region.',
         type: 'string'
     })
     .option('w', {
@@ -68,7 +68,7 @@ var options = yargs
         demandOption: false,
         default: '.env',
         describe: 'The name of the file to write to',
-        type: 'boolean'
+        type: 'string'
     })
 
 


### PR DESCRIPTION
Just a couple of quick edits I made when I first kicked the tires on this.

- Corrected **_fileName_** type from `boolean` to `string` - previously wouldn't allow for the file name to be anything except the default _.env_ , due to it expecting a `boolean`. 

- Clarified `destination` describes to remove duplicates and better match their aliases.